### PR TITLE
Fix(ios): Improve image orientation detection

### DIFF
--- a/ios/ImageUtils.h
+++ b/ios/ImageUtils.h
@@ -6,4 +6,6 @@
 
 + (UIImage *)cropImage:(UIImage *)image toRect:(CGRect)rect;
 
++ (UIImage *)fixOrientation:(UIImage *)image;
+
 @end

--- a/ios/ImageUtils.m
+++ b/ios/ImageUtils.m
@@ -11,4 +11,73 @@
   return image;
 }
 
++ (UIImage *)fixOrientation:(UIImage *)image
+{
+  if (image.imageOrientation == UIImageOrientationUp) {
+    return image;
+  }
+
+  CGAffineTransform transform = CGAffineTransformIdentity;
+  switch (image.imageOrientation) {
+    case UIImageOrientationDown:
+    case UIImageOrientationDownMirrored:
+      transform = CGAffineTransformTranslate(transform, image.size.width, image.size.height);
+      transform = CGAffineTransformRotate(transform, M_PI);
+      break;
+
+    case UIImageOrientationLeft:
+    case UIImageOrientationLeftMirrored:
+      transform = CGAffineTransformTranslate(transform, image.size.width, 0);
+      transform = CGAffineTransformRotate(transform, M_PI_2);
+      break;
+
+    case UIImageOrientationRight:
+    case UIImageOrientationRightMirrored:
+      transform = CGAffineTransformTranslate(transform, 0, image.size.height);
+      transform = CGAffineTransformRotate(transform, -M_PI_2);
+      break;
+
+    default:
+      break;
+  }
+
+  switch (image.imageOrientation) {
+    case UIImageOrientationUpMirrored:
+    case UIImageOrientationDownMirrored:
+      transform = CGAffineTransformTranslate(transform, image.size.width, 0);
+      transform = CGAffineTransformScale(transform, -1, 1);
+      break;
+
+    case UIImageOrientationLeftMirrored:
+    case UIImageOrientationRightMirrored:
+      transform = CGAffineTransformTranslate(transform, image.size.height, 0);
+      transform = CGAffineTransformScale(transform, -1, 1);
+      break;
+
+    default:
+      break;
+  }
+
+  CGContextRef ctx = CGBitmapContextCreate(NULL, image.size.width, image.size.height, CGImageGetBitsPerComponent(image.CGImage), 0, CGImageGetColorSpace(image.CGImage), CGImageGetBitmapInfo(image.CGImage));
+  CGContextConcatCTM(ctx, transform);
+  switch (image.imageOrientation) {
+    case UIImageOrientationLeft:
+    case UIImageOrientationLeftMirrored:
+    case UIImageOrientationRight:
+    case UIImageOrientationRightMirrored:
+      CGContextDrawImage(ctx, CGRectMake(0, 0, image.size.height, image.size.width), image.CGImage);
+      break;
+
+    default:
+      CGContextDrawImage(ctx, CGRectMake(0, 0, image.size.width, image.size.height), image.CGImage);
+      break;
+  }
+
+  CGImageRef cgimg = CGBitmapContextCreateImage(ctx);
+  UIImage *img = [UIImage imageWithCGImage:cgimg];
+  CGContextRelease(ctx);
+  CGImageRelease(cgimg);
+  return img;
+}
+
 @end

--- a/ios/RNImageManipulator.m
+++ b/ios/RNImageManipulator.m
@@ -74,6 +74,7 @@ RCT_EXPORT_METHOD(manipulate:(NSString *)uri
               resolver:(RCTPromiseResolveBlock)resolve
               rejecter:(RCTPromiseRejectBlock)reject
 {
+  image = [ImageUtils fixOrientation:image];
   for (NSDictionary *options in actions) {
     if (options[@"resize"]) {
       float imageWidth = image.size.width;


### PR DESCRIPTION
### Problem

Platform: iOS
Image manipulator is not detecting orientation correctly for images that were captured on iPhone's camera

https://user-images.githubusercontent.com/44551710/183207466-058a3720-1aae-41fd-b175-8922acf0fced.mp4



### Solution

Add a function that fixes orientation before applying any manipulations. (Inspired by expo-image-manipulator)

### Result

https://user-images.githubusercontent.com/44551710/183206404-088cdd9a-7e25-4462-9086-b74a1d524a85.mp4


